### PR TITLE
optimize translations

### DIFF
--- a/sources/index.md
+++ b/sources/index.md
@@ -38,7 +38,7 @@ Keras 兼容的 Python 版本: __Python 2.7-3.6__。
 
 ## 快速开始：30 秒上手 Keras
 
-Keras 的核心数据结构是 __model__，一种组织网络层的方式。最简单的模型是 [`Sequential`](https://keras.io/zh/getting-started/sequential-model-guide) 顺序模型，它是由多个网络层线性堆叠的栈。对于更复杂的结构，你应该使用 [Keras 函数式 API](https://keras.io/zh/getting-started/functional-api-guide)，它允许构建任意的神经网络图。
+Keras 的核心数据结构是 __model__，一种组织网络层的方式。最简单的模型是 [`Sequential`](https://keras.io/zh/getting-started/sequential-model-guide) 顺序模型，它由多个网络层线性堆叠。对于更复杂的结构，你应该使用 [Keras 函数式 API](https://keras.io/zh/getting-started/functional-api-guide)，它允许构建任意的神经网络图。
 
 `Sequential` 顺序模型如下所示：
 


### PR DESCRIPTION
The original text is " The simplest type of model is the Sequential model, a linear *stack* of layers. ".
This sentence has been translated to "最简单的模型是 Sequential 顺序模型，它是由多个网络层线性堆叠的栈。"
"栈"(stack) is a basic data structure,but in fact,sequential model is more like a linear list.So I think this translation should be updated.

 "最简单的模型是 Sequential 顺序模型，它是由多个网络层线性堆叠的栈"，这句翻译进行表述时，将sequential表述为为一个栈的数据结构，而实际上更像一个链表，如果按照字面上的翻译进行直译，容易造成误解，建议修改。