### PR TITLE
change an ambigious expression.

### DIFF
--- a/sources/getting-started/sequential-model-guide.md
+++ b/sources/getting-started/sequential-model-guide.md
@@ -30,7 +30,7 @@ model.add(Activation('relu'))
 
 模型需要知道它所期望的输入的尺寸。出于这个原因，顺序模型中的第一层（且只有第一层，因为下面的层可以自动地推断尺寸）需要接收关于其输入尺寸的信息。有几种方法来做到这一点：
 
-- 传递一个 `input_shape` 参数给第一层。它是一个表示尺寸的元组 (一个整数或 `None` 的元组，其中 `None` 表示可能为任何正整数)。在 `input_shape` 中不包含数据的 batch 大小。
+- 传递一个 `input_shape` 参数给第一层。它是一个表示尺寸的元组 (一个由整数或 `None` 组成的元组，其中 `None` 表示可能为任何正整数)。在 `input_shape` 中不包含数据的 batch 大小。
 - 某些 2D 层，例如 `Dense`，支持通过参数 `input_dim` 指定输入尺寸，某些 3D 时序层支持 `input_dim` 和 `input_length` 参数。
 - 如果你需要为你的输入指定一个固定的 batch 大小（这对 stateful RNNs 很有用），你可以传递一个 `batch_size` 参数给一个层。如果你同时将 `batch_size=32` 和 `input_shape=(6, 8)` 传递给一个层，那么每一批输入的尺寸就为 `(32，6，8)`。
 


### PR DESCRIPTION
Reduce ambiguity:
以前：**“一个整数或 `None` 的元组”** 容易理解为 **“一个整数” 或 “None 元组”**
现在：**“一个由整数或 `None` 组成的元组”** 则没有歧义